### PR TITLE
update to IBM Cloud

### DIFF
--- a/Download-OpenVPN-Configuration-Example/DownloadVpnCfg.properties
+++ b/Download-OpenVPN-Configuration-Example/DownloadVpnCfg.properties
@@ -22,7 +22,7 @@
 
 ################################################################################
 # --Required--
-# HOST:                   WASaaS Broker API Host     (Example: https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1)
+# HOST:                   WASaaS Broker API Host     (Example: https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1)
 # ORGANIZATION:           Personal Organization name (Example: johndoe@ibm.com)
 # SPACE:                  Personal Space name        (Example: dev)
 # SERVICE_INSTANCE_ID:    The Service Instance ID containing the nodes (Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd)
@@ -33,8 +33,8 @@ HOST="YOUR_HOST_URL"
 ORGANIZATION="YOUR_ORGANIZATION"
 SPACE="YOUR_SPACE"
 SERVICE_INSTANCE_ID="YOUR_SERVICE_INSTANCE_ID"
-# either set BASIC_AUTH or 
-#BASIC_AUTH="Basic YOUR_BASIC_AUTHENTICATION_TOKEN"
+# either set BASIC_AUTH
+# BASIC_AUTH="Basic YOUR_BASIC_AUTHENTICATION_TOKEN"
 # or
-# use single use passcode on command line for federated id authentication
+# use a single use passcode on command line for federated id authentication
 

--- a/Download-OpenVPN-Configuration-Example/DownloadVpnCfg.sh
+++ b/Download-OpenVPN-Configuration-Example/DownloadVpnCfg.sh
@@ -32,7 +32,7 @@ associated properties file.
 For federated ID authentication, don't set BASIC_AUTH in properties file.
 Instead, obtain a single use passcode and place it on the commandline.  The
 single use passcode may be acquired from the showpasscode.jsp via browser.  E.g.,
-https://login.ng.bluemix.net/UAALoginServerWAR/showpasscode.jsp
+https://identity-1.us-south.iam.cloud.ibm.com/identity/passcode
 EOF
 exit
 }

--- a/Download-OpenVPN-Configuration-Example/README.md
+++ b/Download-OpenVPN-Configuration-Example/README.md
@@ -1,20 +1,20 @@
 # Download OpenVPN configuration Example Script
 
-This script allows consumers to download a configuration document for OpenVPN client access. 
+This script allows consumers to download a configuration document for OpenVPN client access.
 
 ## Running the Script
 
 * Populate Required Fields
   * The following fields must be populated in order to run the script
-      1. HOST         (Example: https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1)                 
-      2. ORGANIZATION (Example: johndoe@ibm.com)          
-      3. SPACE        (Example: dev)           
+      1. HOST         (Example: https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1)
+      2. ORGANIZATION (Example: johndoe@ibm.com)
+      3. SPACE        (Example: dev)
       4. SERVICE_INSTANCE_ID   (Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd)
 
   * Authentication. Either set BASIC_AUTH
       (5). BASIC_AUTH   (Example: Basic 99dj9jf9u7f77f7f7hwh3u4hjjnjk)         
       OR for federated ids use single use passcode on commandline.  Get one using browser from
-      E.g. https://login.ng.bluemix.net/UAALoginServerWAR/showpasscode.jsp
+      E.g. https://identity-1.us-south.iam.cloud.ibm.com/identity/passcode
 
 * Verify that execute permissions are enabled on the script
   * If execute permissions are not enabled run `chmod 755 ScaleService.sh`

--- a/Notice.txt
+++ b/Notice.txt
@@ -1,2 +1,2 @@
 This product includes software originally developed by IBM Corporation
-Copyright 2016 IBM Corp.
+Copyright 2019 IBM Corp.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# WebSphere Application Server in Bluemix
+# WebSphere Application Server in IBM Cloud
 
-IBM [WebSphere Application Server in Bluemix][wasaas_docs_url] is a service in Bluemix that facilitates quick setup on a pre-configured WebSphere Application Server Liberty, Traditional Network Deployment, or Traditional WebSphere instance in a hosted cloud environment.
+IBM [WebSphere Application Server in IBM Cloud][wasaas_docs_url] is a service in IBM Cloud that facilitates quick setup on a pre-configured WebSphere Application Server Liberty, Traditional Network Deployment, or Traditional WebSphere instance in a hosted cloud environment.
 
-WebSphere Application Server in Bluemix provides consumers with pre-configured Traditional WebSphere and Liberty Profile servers. It is hosted on virtual machine guests with root access to the guest operating system. When you are creating your service, choose between Liberty, Traditional ND, or Traditional WebSphere.
+WebSphere Application Server in IBM Cloud provides consumers with pre-configured Traditional WebSphere and Liberty Profile servers. It is hosted on virtual machine guests with root access to the guest operating system. When you are creating your service, choose between Liberty, Traditional ND, or Traditional WebSphere.
 
 You can create and manage this service in 2 ways
 
-  1. In your browser by creating an instance via the [Bluemix Catalog][catalog_url]
-  1. Programmatically using the WebSphere Application Server in Bluemix *API*
+  1. In your browser by creating an instance via the [IBM Cloud Catalog][catalog_url]
+  1. Programmatically using the WebSphere Application Server in IBM Cloud *API*
 
-The example code in the WebSphere-In-Bluemix-API-Examples folder contains Java code that utilizes the API to perform tasks such as:
+The example code in the WebSphere-In-IBM-Cloud-API-Examples folder contains Java code that utilizes the API to perform tasks such as:
 
   * Create a service instance.
   * Read credentials for your machine.
@@ -23,5 +23,5 @@ The example code in the Scaling-Service-Example folder contains a script that ut
   * Start desired number of nodes within a service instance
   * Stop desired number of nodes within a service instance
 
-[wasaas_docs_url]: https://new-console.ng.bluemix.net/docs/services/ApplicationServeronCloud/index.html
-[catalog_url]: https://console.ng.bluemix.net/catalog/services/websphere-application-server/
+[wasaas_docs_url]: https://cloud.ibm.com/docs/services/ApplicationServeronCloud/index.html#about
+[catalog_url]: https://cloud.ibm.com/catalog/services/websphere-application-server

--- a/Scaling-Service-Example/README.md
+++ b/Scaling-Service-Example/README.md
@@ -8,7 +8,7 @@ This script can be used in conjunction with a cron job to start an appropriate w
 
 * Populate Required Fields
   * The following fields must be populated in order to run the script
-      1. HOST         (Example: https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1)                 
+      1. HOST         (Example: https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1)                 
       2. ORGANIZATION (Example: johndoe@ibm.com)          
       3. SPACE        (Example: dev)           
       4. BASIC_AUTH   (Example: Basic 99dj9jf9u7f77f7f7hwh3u4hjjnjk)         

--- a/Scaling-Service-Example/ScaleService.properties
+++ b/Scaling-Service-Example/ScaleService.properties
@@ -21,7 +21,7 @@
 
 
 ################################################################################
-# HOST:                   WASaaS Broker API Host     (Example: https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1)
+# HOST:                   WASaaS Broker API Host     (Example: https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1)
 # ORGANIZATION:           Personal Organization name (Example: johndoe@ibm.com)
 # SPACE:                  Personal Space name        (Example: dev)
 # BASIC_AUTH:             "Basic " + Base 64 Encoded (username + ":" + password) (Example: Basic 99dj9jf9uwh3u4hjjnjk)

--- a/Scaling-Service-Example/ScaleService.sh
+++ b/Scaling-Service-Example/ScaleService.sh
@@ -306,7 +306,7 @@ echo ""
 # Set other variables for use in script
 CurlFlags="-k -i -s"  # -k for ssl ignoring, -i for header info, -s for silent mode
 
-# Retrieve Bearer Token from Bluemix to use API
+# Retrieve Bearer Token from IBM Cloud to use API
 echo "Retrieving bearer token..."
 echo ""
 get_bearer_token

--- a/WebSphere-In-IBM-Cloud-API-Examples/ActionResource.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/ActionResource.java
@@ -2,34 +2,50 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Get info about all service instances.
-public class GetServiceInstances {
-	/* WebSphere Application Server for Bluemix API URL.
+// Apply an action on a resource. For example, stop or start a virtual machine.
+public class ActionResource {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
+		// You can see how to get the service instance ID from the GetServiceInstances sample class.
+		String serviceInstanceID = "<YOUR_SERVICE_INSTANCE_ID>"; // Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd
+		// You can see how to get the resource ID from the GetResources sample class.
+		String resourceID = "<YOUR_RESOURCE_ID>"; // Example: 8dsjo03-939jksdf3-93j38f-93jf-39dfji32
+		// Query string to stop a virtual machine. Can also be "?action=start"
+		String query = "?action=stop";
+
 
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances");
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources/" + resourceID + query);
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
-		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
+		con.setRequestMethod("PUT");
+		con.setDoOutput(true);
+
+		// Send mock data with PUT to prevent HTTP 411.
+		OutputStreamWriter out = new OutputStreamWriter(con.getOutputStream());
+		out.write("mock data");
+		out.close();
 
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {

--- a/WebSphere-In-IBM-Cloud-API-Examples/CreateServiceInstance.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/CreateServiceInstance.java
@@ -8,18 +8,20 @@ import java.net.URL;
 
 // Create a service instance.
 public class CreateServiceInstance {
-	/* WebSphere Application Server for Bluemix API URL.
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev 
 
@@ -38,7 +40,7 @@ public class CreateServiceInstance {
 		 * Type:                    The plan type to create.
 		 * 							Enum: ["LibertyCollective", "LibertyCore", "LibertyNDServer", "WASBase", "WASCell", "WASNDServer"]
 		 *
-		 * Name:                    Name your new service icon in Bluemix.
+		 * Name:                    Name your new service icon in IBM Cloud.
 		 *
 		 * ApplicationServerVMSize: The size of the virtual machine.
 		 * 							Enum: [S, M, L, XL, XXL]

--- a/WebSphere-In-IBM-Cloud-API-Examples/DeleteServiceInstance.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/DeleteServiceInstance.java
@@ -5,20 +5,22 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Get info about all resources associated with a service instance.
-public class GetResources {
-	/* WebSphere Application Server for Bluemix API URL.
+// Delete a single service instance.
+public class DeleteServiceInstance {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
 		// You can see how to get a service instance ID from the GetServiceInstances sample class.
@@ -28,29 +30,27 @@ public class GetResources {
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources");
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID);
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
-		con.setRequestMethod("GET");
+		con.setRequestMethod("DELETE");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
 
-		BufferedReader br = null;
-		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
-			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+		if (HttpURLConnection.HTTP_NO_CONTENT == con.getResponseCode()) {
+			System.out.println("Successfully Deleted.");
 		}
 		else {
-			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+			BufferedReader br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+			StringBuffer response = new StringBuffer();
+			String line;
+
+			while ((line = br.readLine()) != null) {
+				response.append(line);
+			}
+			br.close();
+
+			// Response from the request.
+			System.out.println(response.toString());
 		}
-
-		StringBuffer response = new StringBuffer();
-		String line;
-
-		while ((line = br.readLine()) != null) {
-			response.append(line);
-		}
-		br.close();
-
-		// Response from the request.
-		System.out.println(response.toString());
 	}
 
 }

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetOAuthToken.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetOAuthToken.java
@@ -5,40 +5,48 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Query a space associated with an organization.
-public class GetSpace {
-	/* WebSphere Application Server for Bluemix API URL.
+import javax.xml.bind.DatatypeConverter;
+
+// Retrieve your OAuth token needed to use this API.
+public class GetOAuthToken {
+	/* WebSphere Application Server for IBM Cloud API URL. 
+	 * The access token returned from this call will only work for the environment URL you generate it with.
+	 * 
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
-	public static void main(String[] args) throws IOException{
-		// You can see how to get your access token from GetOAuthToken sample class.
-		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
-		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
-		String space = "<YOUR_SPACE>"; // Example: dev
-
+	public static void main(String[] args) throws IOException{		
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
-
+		
+		String ibmCloudUsername = "<YOUR_USERNAME>";
+		String ibmCloudPassword = "<YOUR_PASSWORD>";
+		
+		// Create the Basic auth string.
+		String authStr = ibmCloudUsername + ":" + ibmCloudPassword;
+		// Base64 Encode the username and password.
+		String authEncoded = DatatypeConverter.printBase64Binary(authStr.getBytes());
+		
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space);
-		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
+		URL oauthURL = new URL(apiEndpoint + "/oauth");
+		HttpURLConnection con = (HttpURLConnection) oauthURL.openConnection();
 		con.setRequestMethod("GET");
-		con.setRequestProperty("Authorization", "Bearer " + accessToken);
+		con.setRequestProperty("Authorization", "Basic " + authEncoded);
 
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
 			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
-		}
+		} 
 		else {
 			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
 		}
-
+		
 		StringBuffer response = new StringBuffer();
 		String line;
 
@@ -50,7 +58,7 @@ public class GetSpace {
 		// Response from the request.
 		System.out.println(response.toString());
 	}
-
+	
 }
 //    ------------------------------------------------------------------------------
 //     Licensed under the Apache License, Version 2.0 (the "License");

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetOrganization.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetOrganization.java
@@ -5,46 +5,41 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import javax.xml.bind.DatatypeConverter;
-
-// Retrieve your OAuth token needed to use this API.
-public class GetOAuthToken {
-	/* WebSphere Application Server for Bluemix API URL. 
-	 * The access token returned from this call will only work for the environment URL you generate it with.
-	 * 
+// Query information about a single organization.
+public class GetOrganization {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
-	public static void main(String[] args) throws IOException{		
+	public static void main(String[] args) throws IOException{
+		// You can see how to get your access token from GetOAuthToken sample class.
+		String accessToken = "<YOUR_ACCESS_TOKEN>";
+		// The IBM Cloud organization to query - case sensitive.
+		String org = "<YOUR_ORG>"; // Example: dev
+
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
-		
-		String bluemixUsername = "<YOUR_USERNAME>";
-		String bluemixPassword = "<YOUR_PASSWORD>";
-		
-		// Create the Basic auth string.
-		String authStr = bluemixUsername + ":" + bluemixPassword;
-		// Base64 Encode the username and password.
-		String authEncoded = DatatypeConverter.printBase64Binary(authStr.getBytes());
-		
+
 		// Create the URL.
-		URL oauthURL = new URL(apiEndpoint + "/oauth");
-		HttpURLConnection con = (HttpURLConnection) oauthURL.openConnection();
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org);
+		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
-		con.setRequestProperty("Authorization", "Basic " + authEncoded);
+		con.setRequestProperty("Authorization", "Bearer " + accessToken);
 
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
 			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
-		} 
+		}
 		else {
 			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
 		}
-		
+
 		StringBuffer response = new StringBuffer();
 		String line;
 
@@ -56,7 +51,7 @@ public class GetOAuthToken {
 		// Response from the request.
 		System.out.println(response.toString());
 	}
-	
+
 }
 //    ------------------------------------------------------------------------------
 //     Licensed under the Apache License, Version 2.0 (the "License");

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetOrganizations.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetOrganizations.java
@@ -5,27 +5,27 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Query information about a single organization.
-public class GetOrganization {
-	/* WebSphere Application Server for Bluemix API URL.
+// Get all organizations associated with your IBM Cloud account.
+public class GetOrganizations {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization to query - case sensitive.
-		String org = "<YOUR_ORG>"; // Example: dev
-
+		
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
-
+        
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org);
+		URL orgsURL = new URL(apiEndpoint + "/organizations");
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
@@ -33,11 +33,11 @@ public class GetOrganization {
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
 			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
-		}
+		} 
 		else {
 			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
 		}
-
+		
 		StringBuffer response = new StringBuffer();
 		String line;
 
@@ -49,7 +49,7 @@ public class GetOrganization {
 		// Response from the request.
 		System.out.println(response.toString());
 	}
-
+	
 }
 //    ------------------------------------------------------------------------------
 //     Licensed under the Apache License, Version 2.0 (the "License");

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetResource.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetResource.java
@@ -2,48 +2,40 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Apply an action on a resource. For example, stop or start a virtual machine.
-public class ActionResource {
-	/* WebSphere Application Server for Bluemix API URL.
+// Get info about a single resource associated with a service instance.
+public class GetResource {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
-		// You can see how to get the service instance ID from the GetServiceInstances sample class.
+		// You can see how to get a service instance ID from the GetServiceInstances sample class.
 		String serviceInstanceID = "<YOUR_SERVICE_INSTANCE_ID>"; // Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd
-		// You can see how to get the resource ID from the GetResources sample class.
+		// You can see how to get a resource ID from the GetResources sample class.
 		String resourceID = "<YOUR_RESOURCE_ID>"; // Example: 8dsjo03-939jksdf3-93j38f-93jf-39dfji32
-		// Query string to stop a virtual machine. Can also be "?action=start"
-		String query = "?action=stop";
-
 
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources/" + resourceID + query);
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources/" + resourceID);
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
+		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
-		con.setRequestMethod("PUT");
-		con.setDoOutput(true);
-
-		// Send mock data with PUT to prevent HTTP 411.
-		OutputStreamWriter out = new OutputStreamWriter(con.getOutputStream());
-		out.write("mock data");
-		out.close();
 
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetResources.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetResources.java
@@ -5,20 +5,22 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Delete a single service instance.
-public class DeleteServiceInstance {
-	/* WebSphere Application Server for Bluemix API URL.
+// Get info about all resources associated with a service instance.
+public class GetResources {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
 		// You can see how to get a service instance ID from the GetServiceInstances sample class.
@@ -28,27 +30,29 @@ public class DeleteServiceInstance {
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID);
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources");
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
-		con.setRequestMethod("DELETE");
+		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
 
-		if (HttpURLConnection.HTTP_NO_CONTENT == con.getResponseCode()) {
-			System.out.println("Successfully Deleted.");
+		BufferedReader br = null;
+		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
+			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
 		}
 		else {
-			BufferedReader br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
-			StringBuffer response = new StringBuffer();
-			String line;
-
-			while ((line = br.readLine()) != null) {
-				response.append(line);
-			}
-			br.close();
-
-			// Response from the request.
-			System.out.println(response.toString());
+			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
 		}
+
+		StringBuffer response = new StringBuffer();
+		String line;
+
+		while ((line = br.readLine()) != null) {
+			response.append(line);
+		}
+		br.close();
+
+		// Response from the request.
+		System.out.println(response.toString());
 	}
 
 }

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetServiceInstance.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetServiceInstance.java
@@ -5,32 +5,32 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Get info about a single resource associated with a service instance.
-public class GetResource {
-	/* WebSphere Application Server for Bluemix API URL.
+// Query information about a single service instance.
+public class GetServiceInstance {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
 		// You can see how to get a service instance ID from the GetServiceInstances sample class.
 		String serviceInstanceID = "<YOUR_SERVICE_INSTANCE_ID>"; // Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd
-		// You can see how to get a resource ID from the GetResources sample class.
-		String resourceID = "<YOUR_RESOURCE_ID>"; // Example: 8dsjo03-939jksdf3-93j38f-93jf-39dfji32
 
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID + "/resources/" + resourceID);
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID);
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetServiceInstances.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetServiceInstances.java
@@ -5,30 +5,30 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Query information about a single service instance.
-public class GetServiceInstance {
-	/* WebSphere Application Server for Bluemix API URL.
+// Get info about all service instances.
+public class GetServiceInstances {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization & space to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
 		String space = "<YOUR_SPACE>"; // Example: dev
-		// You can see how to get a service instance ID from the GetServiceInstances sample class.
-		String serviceInstanceID = "<YOUR_SERVICE_INSTANCE_ID>"; // Example: dc8djk2-ddbf-43n33-ba4e-132094dn3imd
 
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances/" + serviceInstanceID);
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space + "/serviceinstances");
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetSpace.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetSpace.java
@@ -5,27 +5,30 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Get all spaces associated with an organization.
-public class GetSpaces {
-	/* WebSphere Application Server for Bluemix API URL.
+// Query a space associated with an organization.
+public class GetSpace {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		// The Bluemix organization to query - case sensitive.
+		// The IBM Cloud organization & space to query - case sensitive.
 		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
+		String space = "<YOUR_SPACE>"; // Example: dev
 
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
 
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces");
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces/" + space);
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);

--- a/WebSphere-In-IBM-Cloud-API-Examples/GetSpaces.java
+++ b/WebSphere-In-IBM-Cloud-API-Examples/GetSpaces.java
@@ -5,25 +5,29 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-// Get all organizations associated with your Bluemix account.
-public class GetOrganizations {
-	/* WebSphere Application Server for Bluemix API URL.
+// Get all spaces associated with an organization.
+public class GetSpaces {
+	/* WebSphere Application Server for IBM Cloud API URL.
 	 * Available Environments:
-	 * Dallas - https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1
-	 * London - https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api/v1
-	 * Sydney - https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api/v1
+	 * Dallas - https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * London - https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Sydney - https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
+	 * Frankfurt - https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1
 	 */
-	private static final String apiEndpoint = "https://wasaas-broker.ng.bluemix.net/wasaas-broker/api/v1";
+	
+	private static final String apiEndpoint = "https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api/v1";
 
 	public static void main(String[] args) throws IOException{
 		// You can see how to get your access token from GetOAuthToken sample class.
 		String accessToken = "<YOUR_ACCESS_TOKEN>";
-		
+		// The IBM Cloud organization to query - case sensitive.
+		String org = "<YOUR_ORG>"; // Example: johndoe@ibm.com
+
 		// Use TLSv1.2
 		System.setProperty("https.protocols", "TLSv1.2");
-        
+
 		// Create the URL.
-		URL orgsURL = new URL(apiEndpoint + "/organizations");
+		URL orgsURL = new URL(apiEndpoint + "/organizations/" + org + "/spaces");
 		HttpURLConnection con = (HttpURLConnection) orgsURL.openConnection();
 		con.setRequestMethod("GET");
 		con.setRequestProperty("Authorization", "Bearer " + accessToken);
@@ -31,11 +35,11 @@ public class GetOrganizations {
 		BufferedReader br = null;
 		if (HttpURLConnection.HTTP_OK == con.getResponseCode()) {
 			br = new BufferedReader(new InputStreamReader(con.getInputStream()));
-		} 
+		}
 		else {
 			br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
 		}
-		
+
 		StringBuffer response = new StringBuffer();
 		String line;
 
@@ -47,7 +51,7 @@ public class GetOrganizations {
 		// Response from the request.
 		System.out.println(response.toString());
 	}
-	
+
 }
 //    ------------------------------------------------------------------------------
 //     Licensed under the Apache License, Version 2.0 (the "License");

--- a/WebSphere-In-IBM-Cloud-API-Examples/README.md
+++ b/WebSphere-In-IBM-Cloud-API-Examples/README.md
@@ -1,4 +1,4 @@
-# WebSphere Application Server in Bluemix API Usage Examples
+# WebSphere Application Server in IBM Cloud API Usage Examples
 
 The example code in this repository contains Java code that utilizes the API to perform tasks such as:
 
@@ -24,9 +24,7 @@ These examples were built with developer reusability in mind. There is Swagger U
 * [Australia (Sydney)][sydney_swagger_api_url]
 * [Germany (Frankfurt)][frankfurt_swagger_api_url]
 
-[wasaas_docs_url]: https://new-console.ng.bluemix.net/docs/services/ApplicationServeronCloud/index.html
-[catalog_url]: https://console.ng.bluemix.net/catalog/services/websphere-application-server/
-[dallas_swagger_api_url]: https://wasaas-broker.ng.bluemix.net/wasaas-broker/api
-[london_swagger_api_url]: https://wasaas-broker.eu-gb.bluemix.net/wasaas-broker/api
-[sydney_swagger_api_url]: https://wasaas-broker.au-syd.bluemix.net/wasaas-broker/api
-[frankfurt_swagger_api_url]: https://wasaas-broker.eu-de.bluemix.net/wasaas-broker/api
+[dallas_swagger_api_url]: https://wasaas-broker.us-south.websphereappsvr.cloud.ibm.com/wasaas-broker/api
+[london_swagger_api_url]: https://wasaas-broker.eu-gb.websphereappsvr.cloud.ibm.com/wasaas-broker/api
+[sydney_swagger_api_url]: https://wasaas-broker.au-syd.websphereappsvr.cloud.ibm.com/wasaas-broker/api
+[frankfurt_swagger_api_url]: https://wasaas-broker.eu-de.websphereappsvr.cloud.ibm.com/wasaas-broker/api


### PR DESCRIPTION
Moving all references / links from Bluemix to the IBM Cloud equivalent 

Also request to rename this repository to: `WebSphere-in-IBM-Cloud`

and to change the link in the repository description to `https://cloud.ibm.com/catalog/services/websphere-application-server`
 as well as Bluemix -> IBM Cloud in the description too